### PR TITLE
Graph scalability improvements and other graphical changes

### DIFF
--- a/floating.cs
+++ b/floating.cs
@@ -19,7 +19,7 @@ namespace LibreLinkUp_Windows
             private string patientId;
             private System.Timers.Timer glucoseTimer;
             private Label glucoseLabel, avgLabel;
-            private bool isDragging, isHover = false;
+            private bool isDragging, isHovering = false;
             private Point mouseOffset;
             private Chart glucoseChart;
             private NotifyIcon trayIcon;
@@ -183,8 +183,6 @@ namespace LibreLinkUp_Windows
                 HandleMouseExit();
             }
 
-            private bool isHovering = false;
-            private Color nValColor = Color.White;
             private void HandleMouseExit()
             {
                 if (!isHovering) return;
@@ -248,6 +246,7 @@ namespace LibreLinkUp_Windows
             }
 
             private string exVal, nVal;
+            private Color nValColor = Color.White;
 
             double max = 0;
             double min = 999;
@@ -278,14 +277,14 @@ namespace LibreLinkUp_Windows
                         var graphData = JsonGraph.data.graphData;
 
                         var connection = JsonGraph.data.connection;
-                        
+
                         double max_alarm = connection.patientDevice.hl;
                         double min_alarm = connection.patientDevice.ll;
                         double targetHigh = connection.targetHigh;
                         double targetLow = connection.targetLow;
 
-                        //double lastValuei = Math.Round(Convert.ToDouble(connection.glucoseMeasurement.Value) * 18, 0);
-                        string lastValue = connection.glucoseMeasurement.Value; //Convert.ToString(lastValuei); //
+                        //double TESTMGDL = Math.Round(Convert.ToDouble(connection.glucoseMeasurement.Value) * 18, 0);
+                        string lastValue = connection.glucoseMeasurement.Value; // Convert.ToString(TESTMGDL); //
 
                         string unitType = connection.glucoseMeasurement.GlucoseUnits;
 
@@ -314,16 +313,11 @@ namespace LibreLinkUp_Windows
 
                         double newMaxY = Math.Max(targetHigh, Math.Round(max_alarm));
                         double newMinY = Math.Min(targetLow, Math.Round(min_alarm));
-
-                        DateTime.TryParseExact(connection.glucoseMeasurement.Timestamp.ToString(), timestampFormat,
-                                                        System.Globalization.CultureInfo.InvariantCulture,
-                                                        System.Globalization.DateTimeStyles.None,
-                                                        out DateTime lastTimestamp);
                         int trendArrowValue = connection.glucoseMeasurement.TrendArrow;
                         bool high = connection.glucoseMeasurement.isHigh;
                         bool low = connection.glucoseMeasurement.isLow;
                         int MeasurementColor = connection.glucoseMeasurement.MeasurementColor;
-                        
+
 
                         string trendArrow = null;
 
@@ -370,33 +364,39 @@ namespace LibreLinkUp_Windows
                         }
 
                         // Add current value to chart
+                        if (DateTime.TryParseExact(connection.glucoseMeasurement.Timestamp.ToString(), timestampFormat,
+                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                        System.Globalization.DateTimeStyles.None,
+                                                        out DateTime lastTimestamp))
                         {
-                            double lastValueV = Convert.ToDouble(lastValue);
+                            double glucoseValue = Convert.ToDouble(lastValue);
 
-                            if (lastValueV > max) max = lastValueV;
-                            if (lastValueV < min) min = lastValueV;
+                            if (glucoseValue > max) max = glucoseValue;
+                            if (glucoseValue < min) min = glucoseValue;
+
                             var chartPointCurrent = glucoseChart.Series["Glucose"].Points.AddXY(lastTimestamp, lastValue);
                             glucoseChart.Series["Glucose"].Points[index].MarkerStyle = MarkerStyle.Star5;
                             glucoseChart.Series["Glucose"].Points[index].MarkerBorderColor = Color.Black;
                             glucoseChart.Series["Glucose"].Points[index].MarkerSize = 12;
-                            if (lastValueV > targetHigh || lastValueV < targetLow) offRange++;
 
-                            if (lastValueV < URGENT_LOW * localGlucoseConversion)
+                            if (glucoseValue > targetHigh || glucoseValue < targetLow) offRange++;
+
+                            if (glucoseValue < URGENT_LOW * localGlucoseConversion)
                             {
                                 glucoseChart.Series["Glucose"].Points[index].Color = Color.Red;
                                 glucoseLabel.ForeColor = Color.Red;
                             }
-                            else if (lastValueV < targetLow)
+                            else if (glucoseValue < targetLow)
                             {
                                 glucoseChart.Series["Glucose"].Points[index].Color = Color.FromArgb(255, 200, 0);
                                 glucoseLabel.ForeColor = Color.FromArgb(255, 200, 0);
                             }
-                            else if (lastValueV > URGENT_HIGH * localGlucoseConversion)
+                            else if (glucoseValue > URGENT_HIGH * localGlucoseConversion)
                             {
                                 glucoseChart.Series["Glucose"].Points[index].Color = Color.Red;
                                 glucoseLabel.ForeColor = Color.Red;
                             }
-                            else if (lastValueV > targetHigh)
+                            else if (glucoseValue > targetHigh)
                             {
                                 glucoseChart.Series["Glucose"].Points[index].Color = Color.Orange;
                                 glucoseLabel.ForeColor = Color.Orange;
@@ -406,7 +406,7 @@ namespace LibreLinkUp_Windows
                                 glucoseChart.Series["Glucose"].Points[index].Color = Color.Green;
                                 glucoseLabel.ForeColor = Color.White;
                             }
-                            glucodata += lastValueV;
+                            glucodata += glucoseValue;
                             index++;
                         }
 
@@ -460,7 +460,7 @@ namespace LibreLinkUp_Windows
                         newMinY = Math.Min(newMinY, Math.Floor(min));
                         double avg = glucodata / index;
                         double TIR = 100 - ((offRange * 100) / index);
-                        
+
                         double interval = GetInterval(newMinY, newMaxY, unitType);
                         (double normalizedMinY, double normalizedMaxY) = NormalizeChart(newMinY, newMaxY, interval, unitType);
 
@@ -470,68 +470,73 @@ namespace LibreLinkUp_Windows
                         glucoseChart.ChartAreas[0].AxisY.Minimum = normalizedMinY;
 
                         double axisRange = normalizedMaxY - normalizedMinY;
-                        double stripWidth = Math.Round((axisRange / glucoseChart.Size.Height) * 3,1);
-
+                        double stripWidth = Math.Round((axisRange / glucoseChart.Size.Height) * 3, 1);
 
                         glucoseChart.ChartAreas["ChartArea1"].AxisX.IsMarginVisible = true;
 
-                        StripLine stripLine = new StripLine();
+                        { // Average Glucose Stripline
+                            StripLine stripLine = new StripLine();
 
-                        stripLine.Interval = 0;
-                        stripLine.IntervalOffset = avg;
-                        stripLine.StripWidth = stripWidth;
-                        stripLine.BackColor = Color.Blue;
-                        stripLine.TextAlignment = StringAlignment.Far;
-                        stripLine.TextLineAlignment = StringAlignment.Center;
+                            stripLine.Interval = 0;
+                            stripLine.IntervalOffset = avg;
+                            stripLine.StripWidth = stripWidth;
+                            stripLine.BackColor = Color.Blue;
+                            stripLine.TextAlignment = StringAlignment.Far;
+                            stripLine.TextLineAlignment = StringAlignment.Center;
 
-                        glucoseChart.ChartAreas["ChartArea1"].AxisY.StripLines.Add(stripLine);
+                            glucoseChart.ChartAreas["ChartArea1"].AxisY.StripLines.Add(stripLine);
+                        }
 
                         double stripRange;
 
-                        // Low Stripline
-                        if (min_alarm <= Math.Round(newMinY,0))
-                        {
-                            stripRange = Math.Abs(min_alarm - normalizedMinY);
-                            if (stripRange >= 1) stripRange = 0;
-                        }
-                        else
-                        {
-                            stripRange = 0;
-                        }
-                        stripLine = new StripLine();
+                        { // Low Stripline
+                            StripLine stripLine = new StripLine();
 
-                        stripLine.Interval = 0;
-                        stripLine.IntervalOffset = min_alarm + stripRange;
-                        stripLine.StripWidth = stripWidth;
-                        stripLine.BackColor = Color.Red;
-                        stripLine.TextAlignment = StringAlignment.Far;
-                        stripLine.TextLineAlignment = StringAlignment.Center;
-
-                        glucoseChart.ChartAreas["ChartArea1"].AxisY.StripLines.Add(stripLine);
-
-                        // High Stripline
-                        if (max_alarm >= newMaxY)
-                        {
-                            stripRange = Math.Abs(max_alarm - newMaxY);
-                            if (stripRange >= 1)
-                                stripRange = 0;
+                            if (min_alarm <= Math.Round(newMinY, 0))
+                            {
+                                stripRange = Math.Abs(min_alarm - normalizedMinY);
+                                if (stripRange >= 1) stripRange = 0;
+                            }
                             else
-                                stripRange += (2.7 * localGlucoseConversion);
-                        }
-                        else
-                        {
-                            stripRange = 0;
-                        }
-                        stripLine = new StripLine();
+                            {
+                                stripRange = 0;
+                            }
 
-                        stripLine.Interval = 0;
-                        stripLine.IntervalOffset = max_alarm - stripRange;
-                        stripLine.StripWidth = stripWidth;
-                        stripLine.BackColor = Color.Orange;
-                        stripLine.TextAlignment = StringAlignment.Far;
-                        stripLine.TextLineAlignment = StringAlignment.Center;
+                            stripLine.Interval = 0;
+                            stripLine.IntervalOffset = min_alarm + stripRange;
+                            stripLine.StripWidth = stripWidth;
+                            stripLine.BackColor = Color.Red;
+                            stripLine.TextAlignment = StringAlignment.Far;
+                            stripLine.TextLineAlignment = StringAlignment.Center;
 
-                        glucoseChart.ChartAreas["ChartArea1"].AxisY.StripLines.Add(stripLine);
+                            glucoseChart.ChartAreas["ChartArea1"].AxisY.StripLines.Add(stripLine);
+                        }
+
+                        { // High Stripline
+                            StripLine stripLine = new StripLine();
+
+                            if (max_alarm >= newMaxY)
+                            {
+                                stripRange = Math.Abs(max_alarm - newMaxY);
+                                if (stripRange >= 1)
+                                    stripRange = 0;
+                                else
+                                    stripRange += (2.7 * localGlucoseConversion);
+                            }
+                            else
+                            {
+                                stripRange = 0;
+                            }
+                            
+                            stripLine.Interval = 0;
+                            stripLine.IntervalOffset = max_alarm - stripRange;
+                            stripLine.StripWidth = stripWidth;
+                            stripLine.BackColor = Color.Orange;
+                            stripLine.TextAlignment = StringAlignment.Far;
+                            stripLine.TextLineAlignment = StringAlignment.Center;
+
+                            glucoseChart.ChartAreas["ChartArea1"].AxisY.StripLines.Add(stripLine);
+                        }
                         
                         glucoseLabel.Text = $"{lastValue} {unitType} {trendArrow}";
                         nVal = glucoseLabel.Text;

--- a/floating.cs
+++ b/floating.cs
@@ -470,7 +470,7 @@ namespace LibreLinkUp_Windows
                         glucoseChart.ChartAreas[0].AxisY.Minimum = normalizedMinY;
 
                         double axisRange = normalizedMaxY - normalizedMinY;
-                        double stripWidth = (axisRange / glucoseChart.Size.Height) * 3;
+                        double stripWidth = Math.Round((axisRange / glucoseChart.Size.Height) * 3,1);
 
 
                         glucoseChart.ChartAreas["ChartArea1"].AxisX.IsMarginVisible = true;
@@ -513,7 +513,10 @@ namespace LibreLinkUp_Windows
                         if (max_alarm >= newMaxY)
                         {
                             stripRange = Math.Abs(max_alarm - newMaxY);
-                            if (stripRange >= 1) stripRange = 0;
+                            if (stripRange >= 1)
+                                stripRange = 0;
+                            else
+                                stripRange += (2.7 * localGlucoseConversion);
                         }
                         else
                         {
@@ -522,7 +525,7 @@ namespace LibreLinkUp_Windows
                         stripLine = new StripLine();
 
                         stripLine.Interval = 0;
-                        stripLine.IntervalOffset = max_alarm - stripRange - (3.6 * localGlucoseConversion);
+                        stripLine.IntervalOffset = max_alarm - stripRange;
                         stripLine.StripWidth = stripWidth;
                         stripLine.BackColor = Color.Orange;
                         stripLine.TextAlignment = StringAlignment.Far;

--- a/floating.cs
+++ b/floating.cs
@@ -560,6 +560,12 @@ namespace LibreLinkUp_Windows
                         }
                         exVal = $"TIR: {TIR.ToString("0.")}%";
 
+                        if (isHovering) // Stops api replacing label when hovering
+                        {
+                            glucoseLabel.Text = exVal;
+                            glucoseLabel.ForeColor = Color.White;
+                        }
+
                         if (avgLabel.Visible == false)
                             glucoseLabel.Left = (this.ClientSize.Width - glucoseLabel.Width) / 2;
                         //tirLabel.Left = (this.ClientSize.Width - tirLabel.Width) / 2;

--- a/floating.cs
+++ b/floating.cs
@@ -283,8 +283,7 @@ namespace LibreLinkUp_Windows
                         double targetHigh = connection.targetHigh;
                         double targetLow = connection.targetLow;
 
-                        //double TESTMGDL = Math.Round(Convert.ToDouble(connection.glucoseMeasurement.Value) * 18, 0);
-                        string lastValue = connection.glucoseMeasurement.Value; //Convert.ToString(TESTMGDL); //
+                        string lastValue = connection.glucoseMeasurement.Value; 
 
                         string unitType = connection.glucoseMeasurement.GlucoseUnits;
 

--- a/floating.cs
+++ b/floating.cs
@@ -248,8 +248,6 @@ namespace LibreLinkUp_Windows
             private string exVal, nVal;
             private Color nValColor = Color.White;
 
-            double max = 0;
-            double min = 999;
             string con_url = "https://api.libreview.io/llu/connections";
             private async Task GetLatestGlucoseValue()
             {
@@ -278,13 +276,15 @@ namespace LibreLinkUp_Windows
 
                         var connection = JsonGraph.data.connection;
 
+                        double max = 0;
+                        double min = 999;
                         double max_alarm = connection.patientDevice.hl;
                         double min_alarm = connection.patientDevice.ll;
                         double targetHigh = connection.targetHigh;
                         double targetLow = connection.targetLow;
 
                         //double TESTMGDL = Math.Round(Convert.ToDouble(connection.glucoseMeasurement.Value) * 18, 0);
-                        string lastValue = connection.glucoseMeasurement.Value; // Convert.ToString(TESTMGDL); //
+                        string lastValue = connection.glucoseMeasurement.Value; //Convert.ToString(TESTMGDL); //
 
                         string unitType = connection.glucoseMeasurement.GlucoseUnits;
 
@@ -313,13 +313,9 @@ namespace LibreLinkUp_Windows
 
                         double newMaxY = Math.Max(targetHigh, Math.Round(max_alarm));
                         double newMinY = Math.Min(targetLow, Math.Round(min_alarm));
-                        int trendArrowValue = connection.glucoseMeasurement.TrendArrow;
                         bool high = connection.glucoseMeasurement.isHigh;
                         bool low = connection.glucoseMeasurement.isLow;
                         int MeasurementColor = connection.glucoseMeasurement.MeasurementColor;
-
-
-                        string trendArrow = null;
 
                         foreach (var dataPoint in graphData)
                         {
@@ -388,18 +384,18 @@ namespace LibreLinkUp_Windows
                             }
                             else if (glucoseValue < targetLow)
                             {
-                                glucoseChart.Series["Glucose"].Points[index].Color = Color.FromArgb(255, 200, 0);
-                                glucoseLabel.ForeColor = Color.FromArgb(255, 200, 0);
-                            }
-                            else if (glucoseValue > URGENT_HIGH * localGlucoseConversion)
-                            {
                                 glucoseChart.Series["Glucose"].Points[index].Color = Color.Red;
                                 glucoseLabel.ForeColor = Color.Red;
                             }
-                            else if (glucoseValue > targetHigh)
+                            else if (glucoseValue > URGENT_HIGH * localGlucoseConversion)
                             {
                                 glucoseChart.Series["Glucose"].Points[index].Color = Color.Orange;
                                 glucoseLabel.ForeColor = Color.Orange;
+                            }
+                            else if (glucoseValue > targetHigh)
+                            {
+                                glucoseChart.Series["Glucose"].Points[index].Color = Color.FromArgb(255, 200, 0);
+                                glucoseLabel.ForeColor = Color.FromArgb(255, 200, 0);
                             }
                             else
                             {
@@ -410,6 +406,8 @@ namespace LibreLinkUp_Windows
                             index++;
                         }
 
+                        string trendArrow = null;
+                        int trendArrowValue = connection.glucoseMeasurement.TrendArrow;
                         double gentleBuffer = 25 * localGlucoseConversion;
                         double sharpDropBuffer = 35 * localGlucoseConversion;
                         double sharpRiseBuffer = 50 * localGlucoseConversion;
@@ -451,12 +449,22 @@ namespace LibreLinkUp_Windows
                                     lastValue.Insert(0, "⚠️");
                                 }
                                 break;
-                            default:
+                            case 0:
+                                if (high) 
+                                { 
+                                    lastValue = "⚠️HI"; 
+                                    glucoseLabel.ForeColor = Color.Orange; 
+                                }
+                                if (low) 
+                                { 
+                                    lastValue = "⚠️LO"; 
+                                    glucoseLabel.ForeColor = Color.Red; 
+                                }
                                 break;
                         }
                         ;
 
-                        newMaxY = Math.Max(newMaxY, Math.Ceiling(max));
+                        newMaxY = Math.Max(newMaxY, RoundHalfCeiling(max));
                         newMinY = Math.Min(newMinY, Math.Floor(min));
                         double avg = glucodata / index;
                         double TIR = 100 - ((offRange * 100) / index);
@@ -492,14 +500,11 @@ namespace LibreLinkUp_Windows
                         { // Low Stripline
                             StripLine stripLine = new StripLine();
 
+                            stripRange = 0;
                             if (min_alarm <= Math.Round(newMinY, 0))
                             {
                                 stripRange = Math.Abs(min_alarm - normalizedMinY);
                                 if (stripRange >= 1) stripRange = 0;
-                            }
-                            else
-                            {
-                                stripRange = 0;
                             }
 
                             stripLine.Interval = 0;
@@ -515,17 +520,13 @@ namespace LibreLinkUp_Windows
                         { // High Stripline
                             StripLine stripLine = new StripLine();
 
+                            stripRange = (2 * localGlucoseConversion); //Move the line just under the set alarm line
+
                             if (max_alarm >= newMaxY)
                             {
-                                stripRange = Math.Abs(max_alarm - newMaxY);
-                                if (stripRange >= 1)
-                                    stripRange = 0;
-                                else
-                                    stripRange += (2.7 * localGlucoseConversion);
-                            }
-                            else
-                            {
-                                stripRange = 0;
+                                double stripRangeOffset = Math.Abs(max_alarm - newMaxY);
+                                if (stripRangeOffset < 1) // Tries to round down to adjust for graph offset, only really applies to mmol/l
+                                    stripRange += stripRangeOffset;
                             }
                             
                             stripLine.Interval = 0;
@@ -537,8 +538,16 @@ namespace LibreLinkUp_Windows
 
                             glucoseChart.ChartAreas["ChartArea1"].AxisY.StripLines.Add(stripLine);
                         }
-                        
-                        glucoseLabel.Text = $"{lastValue} {unitType} {trendArrow}";
+
+                        if (high || low)
+                        {
+                            glucoseLabel.Text = $"{lastValue}";
+                        }
+                        else
+                        {
+                            glucoseLabel.Text = $"{lastValue} {unitType} {trendArrow}";
+                        }
+
                         nVal = glucoseLabel.Text;
                         nValColor = glucoseLabel.ForeColor;
 
@@ -585,23 +594,41 @@ namespace LibreLinkUp_Windows
                 if (_unitType == "mg/dl")
                 {
                     range = (Math.Ceiling(max / 5) * 5) - (Math.Floor(min / 5) * 5);
-                    for (int i = 5; i < range; i++) // Find a good divisible candidate
+
+                    for (int i = Convert.ToInt32(range); i > 0; i -= 5) // Find a good divisible candidate in 5 increments
                     {
-                        if (range % i == 0 && (range / i) <= 7)
+                        if ((range / i) % 1 == 0 && (range / i) > 4 && (range / i) <= 7)
                         {
                             return i;
                         }
                     }
+
+                    for (int i = Convert.ToInt32(range); i > 0; i -= 5) // Find a good divisible candidate in 5 increments, includes .5 intervals that adjust the YMax later
+                    {
+                        if (((range / i) % 0.5 == 0 || (range / i) % 1 == 0) && (range / i) > 4 && (range / i) <= 7)
+                        {
+                            return i;
+                        }
+                    }
+
+                    for (int i = Convert.ToInt32(range); i > 0; i -= 2) // Find a good divisible candidate in 2 increments worst case
+                    {
+                        if ((range / i) % 1 == 0 && (range / i) > 4 && (range / i) <= 7)
+                        {
+                            return i;
+                        }
+                    }
+
                     return 10;
                 }
                 else
                 {
-                    range = Math.Round(max, 0) - Math.Round(min, 0);
+                    range = RoundHalfCeiling(max) - Math.Round(min, 0);
                     int rangeInt = (int)Math.Round(range * 10);
-                    for (int i = 1; i < rangeInt; i++) // Find a good divisible candidate
+                    for (int i = rangeInt; i != 0; i-=5) // Find a good divisible candidate
                     {
                         double interval = i / 10.0;
-                        if (rangeInt % i == 0 && (rangeInt / i) <= 7)
+                        if ( (rangeInt / i) > 4 && (rangeInt / i) <= 7)
                         {
                             return interval;
                         }
@@ -623,10 +650,20 @@ namespace LibreLinkUp_Windows
                 else
                 {
                     newMin = Math.Round(_min, 0);
-                    newMax = Math.Round(_max, 0);
+                    newMax = RoundHalfCeiling(_max);
                 }
 
+                double epsilon = 1e-9;
+                double adjustedMax = newMin + Math.Ceiling(((newMax - newMin) / _interval) - epsilon) * _interval;
+
+                newMax = adjustedMax;
+
                 return (newMin, newMax);
+            }
+
+            private double RoundHalfCeiling(double value)
+            {
+                return Math.Ceiling(value * 2) / 2.0;
             }
         }
     }

--- a/floating.cs
+++ b/floating.cs
@@ -24,6 +24,8 @@ namespace LibreLinkUp_Windows
             private Chart glucoseChart;
             private NotifyIcon trayIcon;
             private ContextMenuStrip trayMenu;
+            private static int URGENT_HIGH = 250;
+            private static int URGENT_LOW = 55;
 
             public GlucoseForm(string authToken, string sha256Hash, string patientId)
             {
@@ -182,6 +184,7 @@ namespace LibreLinkUp_Windows
             }
 
             private bool isHovering = false;
+            private Color nValColor = Color.White;
             private void HandleMouseExit()
             {
                 if (!isHovering) return;
@@ -194,6 +197,7 @@ namespace LibreLinkUp_Windows
                     glucoseChart.Visible = false;
                     avgLabel.Visible = false;
                     glucoseLabel.Text = nVal;
+                    glucoseLabel.ForeColor = nValColor;
                     this.Width = 150;
                     this.Height = 50;
                 }
@@ -205,6 +209,7 @@ namespace LibreLinkUp_Windows
                 glucoseChart.Visible = true;
                 avgLabel.Visible = true;
                 glucoseLabel.Text = exVal;
+                glucoseLabel.ForeColor = Color.White;
                 this.Width = 350;
                 this.Height = 250;
             }
@@ -272,19 +277,30 @@ namespace LibreLinkUp_Windows
 
                         var graphData = JsonGraph.data.graphData;
 
-
                         var connection = JsonGraph.data.connection;
+                        
+                        double max_alarm = connection.patientDevice.hl;
+                        double min_alarm = connection.patientDevice.ll;
+                        double targetHigh = connection.targetHigh;
+                        double targetLow = connection.targetLow;
 
-                        int glucoseUnits = connection.glucoseMeasurement.GlucoseUnits;
+                        //double lastValuei = Math.Round(Convert.ToDouble(connection.glucoseMeasurement.Value) * 18, 0);
+                        string lastValue = connection.glucoseMeasurement.Value; //Convert.ToString(lastValuei); //
+
+                        string unitType = connection.glucoseMeasurement.GlucoseUnits;
+
+                        unitType = unitType == "1" ? "mg/dl" : "mmol/l";
 
                         double localGlucoseConversion = 1;
-                        if (glucoseUnits == 0) // 0 == mmol/l, 1 == mg/dl
+                        if (unitType == "mmol/l")
                         {
-                            localGlucoseConversion = 1f / 18f;
+                            localGlucoseConversion = 1.0 / 18.0;
+                            max_alarm = Math.Round(max_alarm * localGlucoseConversion, 1);
+                            min_alarm = Math.Round(min_alarm * localGlucoseConversion, 1);
+                            targetHigh = Math.Round(targetHigh * localGlucoseConversion, 1);
+                            targetLow = Math.Round(targetLow * localGlucoseConversion, 1);
+                            lastValue = double.Parse(lastValue).ToString("0.0");
                         }
-
-                        double max_alarm = connection.targetHigh * localGlucoseConversion;
-                        double min_alarm = connection.targetLow * localGlucoseConversion;
 
                         glucoseChart.Series["Glucose"].Points.Clear();
 
@@ -295,22 +311,19 @@ namespace LibreLinkUp_Windows
                         int index = 0;
                         double glucodata = 0;
                         int offRange = 0;
-                        double maxMin = connection.targetHigh * localGlucoseConversion;
-                        double minMax = connection.targetLow * localGlucoseConversion;
 
-                        double baseMaxY = max_alarm;
-                        double newMaxY = Math.Max(baseMaxY, max);
-                        double baseMinY = min_alarm;
-                        double newMinY = Math.Min(baseMinY, min);
+                        double newMaxY = Math.Max(targetHigh, Math.Round(max_alarm));
+                        double newMinY = Math.Min(targetLow, Math.Round(min_alarm));
 
-                        string lastValue = JsonGraph.data.connection.glucoseMeasurement.Value;
-                        int trendArrowValue = JsonGraph.data.connection.glucoseMeasurement.TrendArrow;
-                        bool high = JsonGraph.data.connection.glucoseMeasurement.isHigh;
-                        bool low = JsonGraph.data.connection.glucoseMeasurement.isLow;
-                        int MeasurementColor = JsonGraph.data.connection.glucoseMeasurement.MeasurementColor;
-                        string unitType = JsonGraph.data.connection.glucoseMeasurement.GlucoseUnits;
-
-                        unitType = unitType == "1" ? "mg/dl" : "mmol/l";
+                        DateTime.TryParseExact(connection.glucoseMeasurement.Timestamp.ToString(), timestampFormat,
+                                                        System.Globalization.CultureInfo.InvariantCulture,
+                                                        System.Globalization.DateTimeStyles.None,
+                                                        out DateTime lastTimestamp);
+                        int trendArrowValue = connection.glucoseMeasurement.TrendArrow;
+                        bool high = connection.glucoseMeasurement.isHigh;
+                        bool low = connection.glucoseMeasurement.isLow;
+                        int MeasurementColor = connection.glucoseMeasurement.MeasurementColor;
+                        
 
                         string trendArrow = null;
 
@@ -325,7 +338,7 @@ namespace LibreLinkUp_Windows
                                 if (glucoseValue > max) max = glucoseValue;
                                 if (glucoseValue < min) min = glucoseValue;
 
-                                if (glucoseValue > maxMin || glucoseValue < minMax) offRange++;
+                                if (glucoseValue > targetHigh || glucoseValue < targetLow) offRange++;
 
                                 string measurementColor = dataPoint.MeasurementColor.ToString();
                                 var chartPoint = glucoseChart.Series["Glucose"].Points.AddXY(timestamp, glucoseValue);
@@ -334,35 +347,78 @@ namespace LibreLinkUp_Windows
                                 {
                                     case "1":
                                         glucoseChart.Series["Glucose"].Points[index].Color = Color.Green;
-                                        glucoseLabel.ForeColor = Color.White;
                                         break;
                                     case "2":
-                                        glucoseChart.Series["Glucose"].Points[index].Color = Color.Yellow;
-                                        glucoseLabel.ForeColor = Color.Yellow;
+                                        glucoseChart.Series["Glucose"].Points[index].Color = Color.FromArgb(255, 200, 0);
                                         break;
                                     case "3":
                                         glucoseChart.Series["Glucose"].Points[index].Color = Color.Orange;
-                                        glucoseLabel.ForeColor = Color.Orange;
                                         break;
                                     case "4":
                                         glucoseChart.Series["Glucose"].Points[index].Color = Color.Red;
-                                        glucoseLabel.ForeColor = Color.Red;
                                         break;
                                     default:
                                         glucoseChart.Series["Glucose"].Points[index].Color = Color.Gray;
-                                        glucoseLabel.ForeColor = Color.White;
                                         break;
-                                }
+                                } // 2:10:43 Last graphed data -> At 2:44:00RT | 2:25:43 data posted
+                                  // ~18 min API delivery delay + ~5-10 min sensor lag = ~23-28 min total delay
+                                  // between actual glucose and what appears on the API response.
+                                  // Color of label must be moved.
                                 glucodata += glucoseValue;
                                 index++;
                             }
                         }
 
+                        // Add current value to chart
+                        {
+                            double lastValueV = Convert.ToDouble(lastValue);
+
+                            if (lastValueV > max) max = lastValueV;
+                            if (lastValueV < min) min = lastValueV;
+                            var chartPointCurrent = glucoseChart.Series["Glucose"].Points.AddXY(lastTimestamp, lastValue);
+                            glucoseChart.Series["Glucose"].Points[index].MarkerStyle = MarkerStyle.Star5;
+                            glucoseChart.Series["Glucose"].Points[index].MarkerBorderColor = Color.Black;
+                            glucoseChart.Series["Glucose"].Points[index].MarkerSize = 12;
+                            if (lastValueV > targetHigh || lastValueV < targetLow) offRange++;
+
+                            if (lastValueV < URGENT_LOW * localGlucoseConversion)
+                            {
+                                glucoseChart.Series["Glucose"].Points[index].Color = Color.Red;
+                                glucoseLabel.ForeColor = Color.Red;
+                            }
+                            else if (lastValueV < targetLow)
+                            {
+                                glucoseChart.Series["Glucose"].Points[index].Color = Color.FromArgb(255, 200, 0);
+                                glucoseLabel.ForeColor = Color.FromArgb(255, 200, 0);
+                            }
+                            else if (lastValueV > URGENT_HIGH * localGlucoseConversion)
+                            {
+                                glucoseChart.Series["Glucose"].Points[index].Color = Color.Red;
+                                glucoseLabel.ForeColor = Color.Red;
+                            }
+                            else if (lastValueV > targetHigh)
+                            {
+                                glucoseChart.Series["Glucose"].Points[index].Color = Color.Orange;
+                                glucoseLabel.ForeColor = Color.Orange;
+                            }
+                            else
+                            {
+                                glucoseChart.Series["Glucose"].Points[index].Color = Color.Green;
+                                glucoseLabel.ForeColor = Color.White;
+                            }
+                            glucodata += lastValueV;
+                            index++;
+                        }
+
+                        double gentleBuffer = 25 * localGlucoseConversion;
+                        double sharpDropBuffer = 35 * localGlucoseConversion;
+                        double sharpRiseBuffer = 50 * localGlucoseConversion;
+
                         switch (trendArrowValue)
                         {
                             case 1:
                                 trendArrow = "⬇️";
-                                if (Convert.ToInt32(lastValue) <= (connection.targetLow + 50) * localGlucoseConversion)
+                                if (Convert.ToDouble(lastValue) <= (Convert.ToDouble(connection.targetLow) * localGlucoseConversion) + sharpDropBuffer)
                                 {
                                     glucoseLabel.ForeColor = Color.Red;
                                     lastValue.Insert(0, "⚠️");
@@ -370,7 +426,7 @@ namespace LibreLinkUp_Windows
                                 break;
                             case 2:
                                 trendArrow = "↘️";
-                                if (Convert.ToInt32(lastValue) <= (connection.targetLow + 25) * localGlucoseConversion)
+                                if (Convert.ToDouble(lastValue) <= (Convert.ToDouble(connection.targetLow) * localGlucoseConversion) + gentleBuffer)
                                 {
                                     glucoseLabel.ForeColor = Color.Red;
                                     lastValue.Insert(0, "⚠️");
@@ -381,17 +437,17 @@ namespace LibreLinkUp_Windows
                                 break;
                             case 4:
                                 trendArrow = "↗️";
-                                if (Convert.ToInt32(lastValue) >= (connection.targetHigh - 25) * localGlucoseConversion)
+                                if (Convert.ToDouble(lastValue) >= (Convert.ToDouble(connection.targetHigh) * localGlucoseConversion) + gentleBuffer)
                                 {
-                                    glucoseLabel.ForeColor = Color.Yellow;
+                                    glucoseLabel.ForeColor = Color.FromArgb(255, 200, 0);
                                     lastValue.Insert(0, "⚠️");
                                 }
                                 break;
                             case 5:
                                 trendArrow = "⬆️";
-                                if (Convert.ToInt32(lastValue) >= (connection.targetHigh - 50) * localGlucoseConversion)
+                                if (Convert.ToDouble(lastValue) >= (Convert.ToDouble(connection.targetHigh) * localGlucoseConversion) + sharpRiseBuffer)
                                 {
-                                    glucoseLabel.ForeColor = Color.Yellow;
+                                    glucoseLabel.ForeColor = Color.Orange;
                                     lastValue.Insert(0, "⚠️");
                                 }
                                 break;
@@ -400,16 +456,22 @@ namespace LibreLinkUp_Windows
                         }
                         ;
 
-                        if (unitType == "mmol/l")
-                        {
-                            (newMinY, newMaxY) = mmolNormalizeChart(newMinY, newMaxY);
-                        }
-
-                        glucoseChart.ChartAreas[0].AxisY.Maximum = newMaxY;
-                        glucoseChart.ChartAreas[0].AxisY.Minimum = newMinY;
-
+                        newMaxY = Math.Max(newMaxY, Math.Ceiling(max));
+                        newMinY = Math.Min(newMinY, Math.Floor(min));
                         double avg = glucodata / index;
                         double TIR = 100 - ((offRange * 100) / index);
+                        
+                        double interval = GetInterval(newMinY, newMaxY, unitType);
+                        (double normalizedMinY, double normalizedMaxY) = NormalizeChart(newMinY, newMaxY, interval, unitType);
+
+                        glucoseChart.ChartAreas[0].AxisY.LabelStyle.Format = "";
+                        glucoseChart.ChartAreas[0].AxisY.Interval = interval;
+                        glucoseChart.ChartAreas[0].AxisY.Maximum = normalizedMaxY;
+                        glucoseChart.ChartAreas[0].AxisY.Minimum = normalizedMinY;
+
+                        double axisRange = normalizedMaxY - normalizedMinY;
+                        double stripWidth = (axisRange / glucoseChart.Size.Height) * 3;
+
 
                         glucoseChart.ChartAreas["ChartArea1"].AxisX.IsMarginVisible = true;
 
@@ -417,17 +479,70 @@ namespace LibreLinkUp_Windows
 
                         stripLine.Interval = 0;
                         stripLine.IntervalOffset = avg;
-                        stripLine.StripWidth = unitType == "mg/dl" ? 2 : 0.18f;
+                        stripLine.StripWidth = stripWidth;
                         stripLine.BackColor = Color.Blue;
                         stripLine.TextAlignment = StringAlignment.Far;
                         stripLine.TextLineAlignment = StringAlignment.Center;
 
                         glucoseChart.ChartAreas["ChartArea1"].AxisY.StripLines.Add(stripLine);
 
+                        double stripRange;
+
+                        // Low Stripline
+                        if (min_alarm <= Math.Round(newMinY,0))
+                        {
+                            stripRange = Math.Abs(min_alarm - normalizedMinY);
+                            if (stripRange >= 1) stripRange = 0;
+                        }
+                        else
+                        {
+                            stripRange = 0;
+                        }
+                        stripLine = new StripLine();
+
+                        stripLine.Interval = 0;
+                        stripLine.IntervalOffset = min_alarm + stripRange;
+                        stripLine.StripWidth = stripWidth;
+                        stripLine.BackColor = Color.Red;
+                        stripLine.TextAlignment = StringAlignment.Far;
+                        stripLine.TextLineAlignment = StringAlignment.Center;
+
+                        glucoseChart.ChartAreas["ChartArea1"].AxisY.StripLines.Add(stripLine);
+
+                        // High Stripline
+                        if (max_alarm >= newMaxY)
+                        {
+                            stripRange = Math.Abs(max_alarm - newMaxY);
+                            if (stripRange >= 1) stripRange = 0;
+                        }
+                        else
+                        {
+                            stripRange = 0;
+                        }
+                        stripLine = new StripLine();
+
+                        stripLine.Interval = 0;
+                        stripLine.IntervalOffset = max_alarm - stripRange - (3.6 * localGlucoseConversion);
+                        stripLine.StripWidth = stripWidth;
+                        stripLine.BackColor = Color.Orange;
+                        stripLine.TextAlignment = StringAlignment.Far;
+                        stripLine.TextLineAlignment = StringAlignment.Center;
+
+                        glucoseChart.ChartAreas["ChartArea1"].AxisY.StripLines.Add(stripLine);
+                        
                         glucoseLabel.Text = $"{lastValue} {unitType} {trendArrow}";
-                        avgLabel.Text = $"Average: {avg.ToString("0.")} {unitType}";
-                        exVal = $"TIR: {TIR.ToString("0.")}%";
                         nVal = glucoseLabel.Text;
+                        nValColor = glucoseLabel.ForeColor;
+
+                        if (unitType == "mg/dl")
+                        {
+                            avgLabel.Text = $"Average: {avg.ToString("0.")} {unitType}";
+                        }
+                        else
+                        {
+                            avgLabel.Text = $"Average: {avg.ToString("0.0")} {unitType}";
+                        }
+                        exVal = $"TIR: {TIR.ToString("0.")}%";
 
                         if (avgLabel.Visible == false)
                             glucoseLabel.Left = (this.ClientSize.Width - glucoseLabel.Width) / 2;
@@ -438,6 +553,7 @@ namespace LibreLinkUp_Windows
                         glucoseChart.ChartAreas[0].AxisX.LabelStyle.Format = "HH:mm";
                         glucoseChart.ChartAreas[0].AxisX.IntervalType = System.Windows.Forms.DataVisualization.Charting.DateTimeIntervalType.Hours;
                         glucoseChart.ChartAreas[0].AxisX.Interval = 1;
+
 
                         /*if(high)
                             glucoseLabel.ForeColor = Color.Yellow;
@@ -454,18 +570,55 @@ namespace LibreLinkUp_Windows
                 }
             }
 
-            private (double _min, double _max) mmolNormalizeChart(double _min, double _max)
+            double GetInterval(double min, double max, string _unitType)
             {
-                double chartRange = _max - _min;
+                double range;
 
-                double targetRange = Math.Ceiling(chartRange / 5.0) * 5;
+                if (_unitType == "mg/dl")
+                {
+                    range = (Math.Ceiling(max / 5) * 5) - (Math.Floor(min / 5) * 5);
+                    for (int i = 5; i < range; i++) // Find a good divisible candidate
+                    {
+                        if (range % i == 0 && (range / i) <= 7)
+                        {
+                            return i;
+                        }
+                    }
+                    return 10;
+                }
+                else
+                {
+                    range = Math.Round(max, 0) - Math.Round(min, 0);
+                    int rangeInt = (int)Math.Round(range * 10);
+                    for (int i = 1; i < rangeInt; i++) // Find a good divisible candidate
+                    {
+                        double interval = i / 10.0;
+                        if (rangeInt % i == 0 && (rangeInt / i) <= 7)
+                        {
+                            return interval;
+                        }
+                    }
+                    return 1.0;
+                }
+            }
 
-                double step = targetRange / 5;
+            private (double _min, double _max) NormalizeChart(double _min, double _max, double _interval, string _units)
+            {
+                double newMin = _min;
+                double newMax = _max;
 
-                double chartMinY = Math.Floor(_min / step) * step;
-                double chartMaxY = chartMinY + targetRange;
+                if (_units == "mg/dl")
+                {
+                    newMin = (Math.Floor(_min / 5) * 5);
+                    newMax = (Math.Ceiling(_max / 5) * 5);
+                }
+                else
+                {
+                    newMin = Math.Round(_min, 0);
+                    newMax = Math.Round(_max, 0);
+                }
 
-                return (chartMinY, chartMaxY);
+                return (newMin, newMax);
             }
         }
     }

--- a/floating.cs
+++ b/floating.cs
@@ -358,12 +358,20 @@ namespace LibreLinkUp_Windows
                             }
                         }
 
+                        bool noData = false;
+
                         // Add current value to chart
                         if (DateTime.TryParseExact(connection.glucoseMeasurement.Timestamp.ToString(), timestampFormat,
                                                         System.Globalization.CultureInfo.InvariantCulture,
                                                         System.Globalization.DateTimeStyles.None,
                                                         out DateTime lastTimestamp))
                         {
+                            if((DateTime.Now - lastTimestamp).TotalMinutes > 30 ) // Checks if a reading has been taken in the past 30 minutes, reports no data if not
+                            {
+                                noData = true;
+                                lastTimestamp = DateTime.Now;
+                            }
+
                             double glucoseValue = Convert.ToDouble(lastValue);
 
                             if (glucoseValue > max) max = glucoseValue;
@@ -376,7 +384,12 @@ namespace LibreLinkUp_Windows
 
                             if (glucoseValue > targetHigh || glucoseValue < targetLow) offRange++;
 
-                            if (glucoseValue < URGENT_LOW * localGlucoseConversion)
+                            if(noData)
+                            {
+                                glucoseChart.Series["Glucose"].Points[index].Color = Color.RoyalBlue;
+                                glucoseLabel.ForeColor = Color.RoyalBlue;
+                            }
+                            else if (glucoseValue < URGENT_LOW * localGlucoseConversion)
                             {
                                 glucoseChart.Series["Glucose"].Points[index].Color = Color.Red;
                                 glucoseLabel.ForeColor = Color.Red;
@@ -410,6 +423,8 @@ namespace LibreLinkUp_Windows
                         double gentleBuffer = 25 * localGlucoseConversion;
                         double sharpDropBuffer = 35 * localGlucoseConversion;
                         double sharpRiseBuffer = 50 * localGlucoseConversion;
+
+                        if (noData) trendArrowValue = 6;
 
                         switch (trendArrowValue)
                         {
@@ -447,6 +462,9 @@ namespace LibreLinkUp_Windows
                                     glucoseLabel.ForeColor = Color.Orange;
                                     lastValue.Insert(0, "⚠️");
                                 }
+                                break;
+                            case 6:
+                                lastValue = "⏳NO DATA";
                                 break;
                             case 0:
                                 if (high) 
@@ -538,7 +556,7 @@ namespace LibreLinkUp_Windows
                             glucoseChart.ChartAreas["ChartArea1"].AxisY.StripLines.Add(stripLine);
                         }
 
-                        if (high || low)
+                        if (high || low || noData)
                         {
                             glucoseLabel.Text = $"{lastValue}";
                         }


### PR DESCRIPTION
Hi KiSa, been testing this for a couple weeks now and I'm happy with how this looks, however I appreciate that it's quite a lot of changes so feel free to reject it since I know this is your project and it probably reduces the minimalism slightly.

I was able to test with mg/dl by adjusting my data, which was fine but it's not real world data, so I think it might be worth testing this on your end for a week or so just in case you find issues.

Here's how the two versions look with the changes in this PR:

<img width="350" height="250" alt="Chart14" src="https://github.com/user-attachments/assets/aa4eb3c5-a6af-4d15-a63e-ca9d9499ad0f" /><img width="350" height="250" alt="Chart15" src="https://github.com/user-attachments/assets/833b20af-936f-4f11-973e-4976be32b1ef" />

Included is the following changes:
- Current glucose indicated by a star icon which changes color depending on BG. I thought this was useful to see charted as I worked out that there's a 23-28 delay between plotted data being added to the JSON response. This is now also included with TIR calculations.

- Glucose label changes color based on current BG, rather than the last plotted datapoint. The delay can make it confusing why it's red/yellow when BG has returned to a good range up to 28 minutes ago.

- Glucose label updates to 'HI' or 'LO' when those thresholds are reached.

- Adjusted the alerts slightly for sharp drops as they are more urgent.

- 2 new striplines that display the users high and low alarm settings, there's some math in place so that when BG is perfectly in range it pushes the high stripline down a couple of pixels so that they fit nicely between the user's 'good' range

- Improved the scalability math of both mg/dl and mmol/l so that the left hand side of the grid attempts to show 'nice' values; with the rightmost number being a 0 or 5 where possible for mg and .5 or no floating point for mmol. I have completely changed my code from my last PR with the mmol charting and made an effort to include mg/dl this time. This is the main part I've spent the past few weeks testing and adjusting the most and it could do with some real world testing with mg/dl. I've tested it thoroughly with mmol and I'm pleased with it.

- Other minor adjustments; 
-> mmol now shows .0 at the end of the glucose and average labels
-> hovering over the graph when async is called no longer replaces the TIR label with current BG
-> moved min/max variables to inside the function so that the graph can scale back down
-> using a custom 'yellow' color to help visibility 

Additional screenshots showing the variable scaling:

<img width="350" height="250" alt="Chart10" src="https://github.com/user-attachments/assets/c273641c-0d35-40bd-9f12-6bdb2518f7cc" /><img width="350" height="250" alt="Chart11" src="https://github.com/user-attachments/assets/57feef5b-7a5a-4609-8e6f-c06c5d4d0aff" />



